### PR TITLE
[Document] del self

### DIFF
--- a/docs/source/guide.md
+++ b/docs/source/guide.md
@@ -40,9 +40,9 @@ client.add_listener(scrcpy.EVENT_FRAME, on_frame)
 
 [Optional] You can also add a listener to listen the `init` event.
 ```python
-def on_init(self):
+def on_init():
     # Print device name
-    print(self.client.device_name)
+    print(client.device_name)
 client.add_listener(scrcpy.EVENT_INIT, on_init)
 ```
 


### PR DESCRIPTION
Document demo raise,
```
TypeError: on_init() missing 1 required positional argument: 'self'
```
so delete `self`.