### PR TITLE
[Bugfix] Fix `encoder_name` param while initialising Client

### DIFF
--- a/scrcpy/core.py
+++ b/scrcpy/core.py
@@ -33,6 +33,7 @@ class Client:
         lock_screen_orientation: int = LOCK_SCREEN_ORIENTATION_UNLOCKED,
         connection_timeout: int = 3000,
         encoder_name: Optional[str] = None,
+        codec_name: Optional[str] = None,
     ):
         """
         Create a scrcpy client, this client won't be started until you call the start function
@@ -48,6 +49,7 @@ class Client:
             lock_screen_orientation: lock screen orientation, LOCK_SCREEN_ORIENTATION_*
             connection_timeout: timeout for connection, unit is ms
             encoder_name: encoder name, enum: [OMX.google.h264.encoder, OMX.qcom.video.encoder.avc, c2.qti.avc.encoder, c2.android.avc.encoder], default is None (Auto)
+            codec_name: codec name, enum: [h264, h265, av1], default is None (Auto)
         """
         # Check Params
         assert max_width >= 0, "max_width must be greater than or equal to 0"
@@ -66,6 +68,12 @@ class Client:
             "c2.qti.avc.encoder",
             "c2.android.avc.encoder",
         ]
+        assert codec_name in [
+            None, 
+            "h264", 
+            "h265", 
+            "av1"
+        ]
 
         # Params
         self.flip = flip
@@ -77,6 +85,7 @@ class Client:
         self.lock_screen_orientation = lock_screen_orientation
         self.connection_timeout = connection_timeout
         self.encoder_name = encoder_name
+        self.codec_name = codec_name
 
         # Connect to device
         if device is None:
@@ -154,6 +163,8 @@ class Client:
             f"max_size={self.max_width}",
             f"max_fps={self.max_fps}",
             f"video_bit_rate={self.bitrate}",
+            f"video_encoder={self.encoder_name}" if self.encoder_name else "video_encoder=OMX.google.h264.encoder",
+            f"video_codec={self.codec_name}" if self.codec_name else "video_codec=h264",
             "tunnel_forward=true",
             "send_frame_meta=false",
             "control=true",
@@ -161,8 +172,9 @@ class Client:
             "show_touches=false",
             "stay_awake=false",
             "power_off_on_close=false",
-            "clipboard_autosync=false"
+            "clipboard_autosync=false",
         ]
+        print(commands)
 
         self.__server_stream: AdbConnection = self.device.shell(
             commands,


### PR DESCRIPTION
**Situation:**

I noticed that `encoder_name` arguments in constructor of `scrcpy.Client` has been broken since the update for supporting `scrcpy` 2.4. However, I have the requirement to force server to use h264 encoder and codec so as to make it work properly. Therefore, I make these changes.

**Changes:**

1. Make `encoder_name` work again
2. Add `codec_name` param to work with encoder_name
3. Set `encoder_name` (default to `OMX.google.h264.encoder`), `codec_name` (default to `h264`)